### PR TITLE
Add '-' to paste command to add compatibility with Mac OS.

### DIFF
--- a/ruby_one_liners.md
+++ b/ruby_one_liners.md
@@ -136,17 +136,17 @@ $ ruby -e 'x=25; y=12; puts x**y'
 
 ```bash
 $ # sample stdin data
-$ seq 10 | paste -sd,
+$ seq 10 | paste -sd, -
 1,2,3,4,5,6,7,8,9,10
 
 $ # change only first ',' to ' : '
 $ # same as: perl -pe 's/,/ : /'
-$ seq 10 | paste -sd, | ruby -pe 'sub(/,/, " : ")'
+$ seq 10 | paste -sd, - | ruby -pe 'sub(/,/, " : ")'
 1 : 2,3,4,5,6,7,8,9,10
 
 $ # change all ',' to ' : '
 $ # same as: perl -pe 's/,/ : /g'
-$ seq 10 | paste -sd, | ruby -pe 'gsub(/,/, " : ")'
+$ seq 10 | paste -sd, - | ruby -pe 'gsub(/,/, " : ")'
 1 : 2 : 3 : 4 : 5 : 6 : 7 : 8 : 9 : 10
 
 $ # sub(/,/, " : ") is shortcut for $_.sub!(/,/, " : ")
@@ -2581,7 +2581,7 @@ Hello World
 $ ruby -e 'system("wc poem.txt")'
  4 13 65 poem.txt
 
-$ ruby -e 'system("seq 10 | paste -sd, > out.txt")'
+$ ruby -e 'system("seq 10 | paste -sd, - > out.txt")'
 $ cat out.txt
 1,2,3,4,5,6,7,8,9,10
 


### PR DESCRIPTION
The paste commands generated an error as is, but adding the '-' fixed it and continued to work in my Linux VM. Here is the error I got in Mac OS without the hyphen:

usage: paste [-s] [-d delimiters] file ...

Here is the output of `uname -a` on my Mojave 10.14.2 Mac OS system:

`Darwin MacBook-Pro-KB-13.local 18.2.0 Darwin Kernel Version 18.2.0: Mon Nov 12 20:24:46 PST 2018; root:xnu-4903.231.4~2/RELEASE_X86_64 x86_64
`

...and on my Linux system:

`Linux ubuntu 4.15.0-43-generic #46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
`

