### PR TITLE
fixes a bug in gnu_awk.md where the incorrect variable INPLACE_SUFFIX was used. Replaces with inplace::suffix

### DIFF
--- a/gnu_awk.md
+++ b/gnu_awk.md
@@ -926,10 +926,10 @@ $ cat f2
 I bought two bananas and three mangoes
 ```
 
-* to create backups of original file, set `INPLACE_SUFFIX` variable
+* to create backups of original file, set `inplace::suffix` variable
 
 ```bash
-$ awk -i inplace -v INPLACE_SUFFIX='.bkp' '{gsub("three", "3")} 1' f1
+$ awk -i inplace -v inplace::suffix='.bkp' '{gsub("three", "3")} 1' f1
 $ cat f1
 I ate 3 apples
 $ cat f1.bkp


### PR DESCRIPTION
The awk inplace editing section had introduced an incorrect variable 'INPLACE_SUFFIX' for backup. As of gawk 5.0 (not sure about earlier versions), this does not produce the expected result of creating a backup file.

The correct variable to use is `inplace::suffix` as seen in the [official gawk manual](https://www.gnu.org/software/gawk/manual/html_node/Extension-Sample-Inplace.html)